### PR TITLE
Support until executed unlock on raise option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ Locks from when the client pushes the job to the queue. Will be unlocked when th
 sidekiq_options lock: :until_executed
 ```
 
+#### Unlock with Exception
+
+unlock the queue if error being raised while processing the job in until_executed mode.
+
+```ruby
+sidekiq_options unlock_with_exception: true # Default behavior is false
+```
+
 ### Until Timeout
 
 Locks from when the client pushes the job to the queue. Will be unlocked when the specified timeout has been reached.

--- a/lib/sidekiq_unique_jobs/constants.rb
+++ b/lib/sidekiq_unique_jobs/constants.rb
@@ -27,4 +27,5 @@ module SidekiqUniqueJobs
   UNIQUE_PREFIX_KEY         ||= "unique_prefix"
   RETRY_SET                 ||= "retry"
   SCHEDULE_SET              ||= "schedule"
+  UNLOCK_WITH_EXCEPTION     ||= "unlock_with_exception"
 end

--- a/lib/sidekiq_unique_jobs/lock/until_executed.rb
+++ b/lib/sidekiq_unique_jobs/lock/until_executed.rb
@@ -19,6 +19,9 @@ module SidekiqUniqueJobs
           log_warn "the unique_key: #{item[UNIQUE_DIGEST_KEY]} is not locked, allowing job to silently complete"
           nil
         end
+      rescue Exception # rubocop:disable Lint/RescueException
+        delete! if item[UNLOCK_WITH_EXCEPTION] == true
+        raise
       end
     end
   end


### PR DESCRIPTION
## Issue

Until Executedを用いた際に、raiseされるとlockが解除されません。
私は、raiseされた場合にもlockを解除するオプションが欲しくなりました。

## This PR

unlock_even_raised オプションを追加し、 trueの場合はraiseされてもlockを解除します。
このオプションは `Until Executed` でのみ有効です。

## Example

READMEへ追記しました